### PR TITLE
Update the app to ruby 2.7.1 and update puma so the app boots

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 12.6.0
-ruby 2.6.3
+ruby 2.7.1

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gem 'rails', '~> 6.0.0'
 gem 'webpacker', '~> 4.0'
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 4.3.6'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
       httparty
     multi_xml (0.6.0)
     net-ssh (5.2.0)
-    nio4r (2.5.2)
+    nio4r (2.5.4)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     nokogiri (1.10.7-x86-mingw32)
@@ -199,7 +199,7 @@ GEM
       activerecord (>= 4.2)
       activesupport (>= 4.2)
     public_suffix (4.0.1)
-    puma (4.3.1)
+    puma (4.3.6)
       nio4r (~> 2.0)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
@@ -353,7 +353,7 @@ DEPENDENCIES
   net-ssh (~> 5.2)
   pg
   pg_search
-  puma (~> 4.3)
+  puma (~> 4.3.6)
   pundit (~> 2.0.0)
   rails (~> 6.0.0)
   record_tag_helper!


### PR DESCRIPTION
Updates the app to ruby 2.7.1 in development and updates puma so the app will properly boot and have the security fixes from Puma upstream. 